### PR TITLE
Add PG LISTEN/NOTIFY sync for keck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.5",
  "bytes",
  "chrono",
  "dotenvy",
@@ -2477,6 +2478,7 @@ dependencies = [
  "sea-orm",
  "sea-orm-migration",
  "sha2",
+ "sqlx",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/apps/keck/tests/pg_notify.rs
+++ b/apps/keck/tests/pg_notify.rs
@@ -1,0 +1,56 @@
+use std::{io::{BufRead, BufReader}, process::{Child, Command, Stdio}, thread::sleep, time::Duration};
+
+use rand::{thread_rng, Rng};
+
+fn start_server(port: u16, db: &str) -> Child {
+    let mut child = Command::new("cargo")
+        .args(["run", "-p", "keck"])
+        .env("KECK_PORT", port.to_string())
+        .env("DATABASE_URL", db)
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to run command");
+
+    if let Some(ref mut stdout) = child.stdout {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let line = line.expect("Failed to read line");
+            if line.contains("listening on 0.0.0.0:") {
+                break;
+            }
+        }
+    }
+
+    child
+}
+
+#[tokio::test]
+#[ignore = "requires external postgres"]
+async fn blocks_consistent_between_nodes() {
+    let port1 = thread_rng().gen_range(20000..30000);
+    let port2 = port1 + 1;
+    let db = std::env::var("TEST_DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/postgres".into());
+    let c1 = start_server(port1, &db);
+    let c2 = start_server(port2, &db);
+
+    let client = reqwest::Client::new();
+    let ws = "ws1";
+    let block = "b1";
+    let url1 = format!("http://localhost:{port1}/api/block/{ws}/{block}?flavour=text");
+    client
+        .post(url1)
+        .json(&serde_json::json!({"prop:text": "hi"}))
+        .send()
+        .await
+        .unwrap();
+    sleep(Duration::from_secs(1));
+    let url2 = format!("http://localhost:{port2}/api/block/{ws}/{block}");
+    let resp = client.get(url2).send().await.unwrap();
+    assert!(resp.status().is_success());
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["prop:text"], "hi");
+
+    unsafe { libc::kill(c1.id() as i32, libc::SIGTERM) };
+    unsafe { libc::kill(c2.id() as i32, libc::SIGTERM) };
+}

--- a/libs/jwst-storage/Cargo.toml
+++ b/libs/jwst-storage/Cargo.toml
@@ -40,6 +40,8 @@ chrono = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "sync"] }
+base64 = "0.21.4"
+sqlx = { version = "0.7", default-features = false, features = ["postgres", "runtime-tokio-rustls"] }
 
 jwst-core = { workspace = true }
 jwst-codec = { workspace = true }

--- a/libs/jwst-storage/src/storage/mod.rs
+++ b/libs/jwst-storage/src/storage/mod.rs
@@ -51,6 +51,10 @@ impl JwstStorage {
             ),
         };
         let docs = SharedDocDBStorage::init_with_pool(pool.clone(), bucket.clone()).await?;
+        #[cfg(feature = "postgres")]
+        if database.starts_with("postgres") {
+            docs.listen_remote(database).await?;
+        }
 
         Ok(Self {
             pool,


### PR DESCRIPTION
## Summary
- add Postgres LISTEN/NOTIFY listener in storage to broadcast workspace updates
- notify peers on update commits and apply incoming updates locally
- add integration test for multi-node consistency (ignored by default)

## Testing
- `cargo test -p jwst-storage`
- `cargo test -p keck`


------
https://chatgpt.com/codex/tasks/task_e_68c161645fe08332ad71ae61b1c5a3ed